### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Repository for object perception related SQUIRREL packages.
 
 Install dependencies and download the latest v4r debian package before you build squirrel_perception
 
-```rosdep install --from-paths $CATKIN_WS/src/squirrel_perception -i -y```
-
 ```roscd squirrel_perception ```
 
 bash: ``` ./setup.bash```
 
 zsh: ```./setup.zsh```
+
+```rosdep install --from-paths $CATKIN_WS/src/squirrel_perception -i -y```
 
 Please check the [Wiki](https://github.com/squirrel-project/squirrel_perception/wiki) for additional information.


### PR DESCRIPTION
We need to run setup.*sh before rosdep. Otherwise v4r will be an undefined reference
