### PR TITLE
Add missing key to private rosdep file

### DIFF
--- a/squirrel_perception/rosdep/private.yaml
+++ b/squirrel_perception/rosdep/private.yaml
@@ -1,3 +1,5 @@
 # SQUIRREL_PERCEPTION
 v4r:
   ubuntu: ros-indigo-v4r
+classifier_srv_definitions:
+  ubuntu: ros-indigo-classifier-srv-definitions


### PR DESCRIPTION
This will fix the missing rosdep dependency. Strangely this issue did not occur on buildbot.
@ipa-nhg @Senka2112 This should fix the missing dependency issue from #113 
